### PR TITLE
feat(bau): Add Bruno HTTP collection for chs-notification-sender-api …

### DIFF
--- a/bruno/README.md
+++ b/bruno/README.md
@@ -1,0 +1,32 @@
+# CHS Notification Sender API - Bruno Collection
+
+This is a Bruno HTTP collection for testing chs-notification-sender-api.
+
+## Usage
+
+### Using Bruno UI
+1. Open Bruno and load this collection
+2. Choose an environment: local, cidev, or phoenix
+3. Send requests through the UI
+
+### Using Bruno CLI 
+
+
+```bash
+# Install bruno
+brew install bruno
+
+# Install the bruno cli
+npm install -g @usebruno/cli
+```
+
+From the collection directory:
+```bash
+# Run a specific request
+bru run ./requests/healthcheck.bru --env local
+
+# Run all requests
+bru run ./requests --env cidev
+```
+
+Each request contains the required headers for authentication, including ERIC identity headers needed for Companies House API access.

--- a/bruno/chs-notification-sender-api/bruno.json
+++ b/bruno/chs-notification-sender-api/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "chs-notification-sender-api",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/bruno/chs-notification-sender-api/collection.bru
+++ b/bruno/chs-notification-sender-api/collection.bru
@@ -1,0 +1,6 @@
+vars:pre-request {
+  ericIdentity: 67ZeMsvAEgkBWs7tNKacdrPvOmQ
+  ericIdentityType: key
+  ericAuthorisedKeyPrivileges: internal-app
+  ericAuthorisedKeyRoles: *
+}

--- a/bruno/chs-notification-sender-api/environments/cidev.bru
+++ b/bruno/chs-notification-sender-api/environments/cidev.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: https://internalapi.cidev.aws.chdev.org
+}

--- a/bruno/chs-notification-sender-api/environments/local.bru
+++ b/bruno/chs-notification-sender-api/environments/local.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: http://localhost:8005
+}

--- a/bruno/chs-notification-sender-api/environments/phoenix.bru
+++ b/bruno/chs-notification-sender-api/environments/phoenix.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: https://internalapi.phoenix1.aws.chdev.org
+}

--- a/bruno/chs-notification-sender-api/requests/healthcheck.bru
+++ b/bruno/chs-notification-sender-api/requests/healthcheck.bru
@@ -1,0 +1,9 @@
+meta {
+  name: Healthcheck
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/healthcheck
+}

--- a/bruno/chs-notification-sender-api/requests/sendEmail.bru
+++ b/bruno/chs-notification-sender-api/requests/sendEmail.bru
@@ -1,0 +1,42 @@
+meta {
+  name: Send Email Example
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/notification-sender/email
+  body: json
+}
+
+headers {
+  X-Request-Id: email-req-87654321
+  Authorization: {{authorization}}
+  ERIC-Identity: {{ericIdentity}}
+  ERIC-Identity-Type: {{ericIdentityType}}
+  ERIC-Authorised-Key-Privileges: {{ericAuthorisedKeyPrivileges}}
+  ERIC-Authorised-Key-Roles: {{ericAuthorisedKeyRoles}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "sender_details": {
+      "app_id": "chips.send_email",
+      "reference": "PSC-EMAIL-2023-04102",
+      "name": "Companies House Admin",
+      "user_id": "ch-admin-1234",
+      "email_address": "admin@example.com"
+    },
+    "recipient_details": {
+      "name": "Jane Doe",
+      "email_address": "jane.doe@example.com"
+    },
+    "email_details": {
+      "template_id": "psc_verification|email35",
+      "template_version": 1,
+      "personalisation_details": "{\"letter_reference\":\"PSC-EMAIL-2023-04103\",\"company_name\":\"DOE ENTERPRISES LTD\",\"company_id\":\"87654321\",\"psc_type\":\"50%\"}"
+    },
+    "created_at": "2023-04-15T15:45:30Z"
+  }
+}

--- a/bruno/chs-notification-sender-api/requests/sendLetter.bru
+++ b/bruno/chs-notification-sender-api/requests/sendLetter.bru
@@ -1,0 +1,50 @@
+meta {
+  name: Send Letter
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/notification-sender/letter
+  body: json
+}
+
+headers {
+  X-Request-Id: letter-req-12345678
+  Content-Type: application/json
+  Authorization: {{authorization}}
+  ERIC-Identity: {{ericIdentity}}
+  ERIC-Identity-Type: {{ericIdentityType}}
+  ERIC-Authorised-Key-Privileges: {{ericAuthorisedKeyPrivileges}}
+  ERIC-Authorised-Key-Roles: {{ericAuthorisedKeyRoles}}
+}
+
+body:json {
+  {
+    "sender_details": {
+      "app_id": "chips.send_letter",
+      "reference": "PSC-LTR-2023-04102",
+      "name": "Companies House Admin",
+      "user_id": "ch-admin-1234",
+      "email_address": "admin@example.com"
+    },
+    "recipient_details": {
+      "name": "John Smith",
+      "physical_address": {
+        "address_line_1": "123 Business Street",
+        "address_line_2": "Office Park",
+        "address_line_3": "Central District",
+        "address_line_4": "London",
+        "address_line_5": "",
+        "address_line_6": "",
+        "address_line_7": "EC1A 1BB"
+      }
+    },
+    "letter_details": {
+      "template_id": "psc_verification|letter235",
+      "template_version": 1,
+      "personalisation_details": "{\"letter_reference\":\"PSC-LTR-2023-04102\",\"company_name\":\"ACME CORPORATION LTD\",\"company_id\":\"12345678\",\"psc_type\":\"25%\"}"
+    },
+    "created_at": "2023-04-15T14:32:28Z"
+  }
+}


### PR DESCRIPTION
Add Bruno collection to facilitate testing of the chs-notification-sender-api across different environments.

Includes:
- Environment configurations for local, cidev, and phoenix
- Request templates for healthcheck, email sending, and letter sending
- README with setup and usage instructions for both UI and CLI

