### PR TITLE
Adding Global Exception Handler

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chs/notification/sender/api/controller/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/chs/notification/sender/api/controller/GlobalExceptionHandler.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.chs.notification.sender.api.controller;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler { }


### PR DESCRIPTION
DEEP-292 Email: Rest API Validation response

This PR adds the Global Exception Handler to return 400 Bad request instead of 403 Forbidden. 

### Type of change

* [x] Validation response fix

