### PR TITLE
refactor(deep): update NotificationMapper to handle datetime as strings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <junit-jupiter-engine-version>5.11.4</junit-jupiter-engine-version>
         <junit.version>4.13.2</junit.version>
         <kafka-clients.version>3.9.0</kafka-clients.version>
-        <kafka-models.version>3.0.15</kafka-models.version>
+        <kafka-models.version>3.0.17</kafka-models.version>
         <log4j-version>2.24.2</log4j-version>
         <logback-classic.version>1.5.16</logback-classic.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>

--- a/src/main/java/uk/gov/companieshouse/chs/notification/sender/api/mapper/NotificationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/chs/notification/sender/api/mapper/NotificationMapper.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.chs.notification.sender.api.mapper;
 
-import java.time.Instant;
 import java.time.OffsetDateTime;
 
 import org.mapstruct.Mapper;
@@ -16,15 +15,15 @@ import uk.gov.companieshouse.notification.ChsLetterNotification;
 @Mapper(componentModel = "spring")
 public interface NotificationMapper {
 
-    @Mapping(source = "createdAt", target = "createdAt", qualifiedByName = "offsetDateTimeToInstant")
+    @Mapping(source = "createdAt", target = "createdAt", qualifiedByName = "offsetDateTimeToString")
     ChsEmailNotification mapToEmailDetailsRequest(GovUkEmailDetailsRequest govUkEmailDetailsRequest);
 
-    @Mapping(source = "createdAt", target = "createdAt", qualifiedByName = "offsetDateTimeToInstant")
+    @Mapping(source = "createdAt", target = "createdAt", qualifiedByName = "offsetDateTimeToString")
     ChsLetterNotification mapToLetterDetailsRequest(GovUkLetterDetailsRequest govUkLetterDetailsRequest);
 
-    @Named("offsetDateTimeToInstant")
-    static Instant offsetDateTimeToInstant(OffsetDateTime dateTime) {
-        return dateTime != null ? dateTime.toInstant() : null;
+    @Named("offsetDateTimeToString")
+    static String offsetDateTimeToString(OffsetDateTime dateTime) {
+        return dateTime != null ? dateTime.toString() : null;
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/chs/notification/sender/api/TestUtil.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/sender/api/TestUtil.java
@@ -23,6 +23,7 @@ public class TestUtil {
     public static final String DEFAULT_RECIPIENT_EMAIL = "recipient@example.com";
     public static final String DEFAULT_EMAIL_TEMPLATE_ID = "template-uuid-email-12345678";
     public static final String DEFAULT_LETTER_TEMPLATE_ID = "template-uuid-letter-87654321";
+    public static final double DEFAULT_TEMPLATE_VERSION_DOUBLE = 1.0;
     public static final BigDecimal DEFAULT_TEMPLATE_VERSION = new BigDecimal("1.0");
     public static final String DEFAULT_EMAIL_CONTENT = "{\"subject\":\"Test Subject\",\"content\":\"This is a test email\"}";
     public static final String DEFAULT_LETTER_CONTENT = "{\"subject\":\"Test Letter\",\"content\":\"This is a test letter\"}";

--- a/src/test/java/uk/gov/companieshouse/chs/notification/sender/api/mapper/NotificationMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/sender/api/mapper/NotificationMapperTest.java
@@ -1,8 +1,6 @@
 package uk.gov.companieshouse.chs.notification.sender.api.mapper;
 
-import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.temporal.ChronoUnit;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,13 +20,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
-public class NotificationMapperTest {
+class NotificationMapperTest {
 
     @Autowired
     private NotificationMapper notificationMapper;
 
     @Test
-    public void When_MapEmailRequest_Expect_CorrectChsEmailNotification() {
+    void When_MapEmailRequest_Expect_CorrectChsEmailNotification() {
         GovUkEmailDetailsRequest request = TestUtil.createValidEmailRequest();
 
         ChsEmailNotification result = notificationMapper.mapToEmailDetailsRequest(request);
@@ -45,16 +43,16 @@ public class NotificationMapperTest {
         assertEquals(TestUtil.DEFAULT_RECIPIENT_EMAIL, result.getRecipientDetails().getEmailAddress());
         assertNotNull(result.getEmailDetails());
         assertEquals(TestUtil.DEFAULT_EMAIL_TEMPLATE_ID, result.getEmailDetails().getTemplateId());
-        assertEquals(TestUtil.DEFAULT_TEMPLATE_VERSION.toString(), result.getEmailDetails().getTemplateVersion());
+        assertEquals(TestUtil.DEFAULT_TEMPLATE_VERSION_DOUBLE, result.getEmailDetails().getTemplateVersion());
         assertEquals(TestUtil.DEFAULT_EMAIL_CONTENT, result.getEmailDetails().getPersonalisationDetails());
         assertEquals(
-                request.getCreatedAt().toInstant().truncatedTo(ChronoUnit.MILLIS),
-                result.getCreatedAt().truncatedTo(ChronoUnit.MILLIS)
+                request.getCreatedAt().toString(),
+                result.getCreatedAt()
         );
     }
 
     @Test
-    public void When_MapLetterRequest_Expect_CorrectChsLetterNotification() {
+    void When_MapLetterRequest_Expect_CorrectChsLetterNotification() {
         GovUkLetterDetailsRequest request = TestUtil.createValidLetterRequest();
 
         ChsLetterNotification result = notificationMapper.mapToLetterDetailsRequest(request);
@@ -77,25 +75,25 @@ public class NotificationMapperTest {
         assertEquals(TestUtil.DEFAULT_ADDRESS_LINE_7, result.getRecipientDetails().getPhysicalAddress().getAddressLine7());
         assertNotNull(result.getLetterDetails());
         assertEquals(TestUtil.DEFAULT_LETTER_TEMPLATE_ID, result.getLetterDetails().getTemplateId());
-        assertEquals(TestUtil.DEFAULT_TEMPLATE_VERSION.toString(), result.getLetterDetails().getTemplateVersion());
+        assertEquals(TestUtil.DEFAULT_TEMPLATE_VERSION_DOUBLE, result.getLetterDetails().getTemplateVersion());
         assertEquals(TestUtil.DEFAULT_LETTER_CONTENT, result.getLetterDetails().getPersonalisationDetails());
         assertEquals(
-                request.getCreatedAt().toInstant().truncatedTo(ChronoUnit.MILLIS),
-                result.getCreatedAt().truncatedTo(ChronoUnit.MILLIS)
+                request.getCreatedAt().toString(),
+                result.getCreatedAt()
         );
     }
 
     @Test
-    public void When_OffsetDateTimeToInstantMethodCalled_Expect_CorrectConversion() {
+    void When_OffsetDateTimeToInstantMethodCalled_Expect_CorrectConversion() {
         OffsetDateTime dateTime = OffsetDateTime.parse("2023-01-01T12:00:00Z");
 
-        Instant result = NotificationMapper.offsetDateTimeToInstant(dateTime);
+        String result = NotificationMapper.offsetDateTimeToString(dateTime);
 
-        assertEquals(Instant.parse("2023-01-01T12:00:00Z"), result);
+        assertEquals("2023-01-01T12:00Z", result);
     }
 
     @Test
-    public void When_OffsetDateTimeToInstantCalledWithNull_Expect_Null() {
-        assertNull(NotificationMapper.offsetDateTimeToInstant(null));
+    void When_OffsetDateTimeToInstantCalledWithNull_Expect_Null() {
+        assertNull(NotificationMapper.offsetDateTimeToString(null));
     }
 }


### PR DESCRIPTION
- Change mapping method from offsetDateTimeToInstant to offsetDateTimeToString
- Update createdAt handling to convert OffsetDateTime to strings instead of Instant objects
- Modify comparison tests to verify string representation
- Update kafka-models version from 3.0.15 to 3.0.17
- Modernize test class style (remove 'public' modifiers)
- Add DEFAULT_TEMPLATE_VERSION_DOUBLE constant for double comparison

