### PR TITLE
DEEP-287: Sync Bruno test with integration API letter templating

### DIFF
--- a/api-collections/bruno/chs-notification-sender-api/requests/sendLetter.bru
+++ b/api-collections/bruno/chs-notification-sender-api/requests/sendLetter.bru
@@ -7,6 +7,7 @@ meta {
 post {
   url: {{baseUrl}}/notification-sender/letter
   body: json
+  auth: none
 }
 
 headers {
@@ -22,7 +23,7 @@ headers {
 body:json {
   {
     "sender_details": {
-      "app_id": "chips.send_letter",
+      "app_id": "chips",
       "reference": "PSC-LTR-2023-04102",
       "name": "Companies House Admin",
       "user_id": "ch-admin-1234",
@@ -41,9 +42,9 @@ body:json {
       }
     },
     "letter_details": {
-      "template_id": "psc_verification|letter235",
+      "template_id": "direction_letter",
       "template_version": 1,
-      "personalisation_details": "{\"letter_reference\":\"PSC-LTR-2023-04102\",\"company_name\":\"ACME CORPORATION LTD\",\"company_id\":\"12345678\",\"psc_type\":\"25%\"}"
+      "personalisation_details": "{\"psc_full_name\": \"Joe Bloggs\", \"company_name\":\"ACME CORPORATION LTD\", \"deadline_date\": \"18 August 2025\", \"extension_date\": \"1 September 2025\"}"
     },
     "created_at": "2023-04-15T14:32:28Z"
   }


### PR DESCRIPTION
__DEEP-287 WIP__

__Tweak fair weather `Send Letter` test so that it continues to be a fair weather test given changes that have so far taken place in the `chs-gov-uk-notify-integration-api` for DEEP-287.__

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__