### PR TITLE
Bump dependencies and add CVE overrides with UTC test timestamps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <hamcrest-all-version>1.3</hamcrest-all-version>
         <java.version>21</java.version>
         <junit.version>4.13.2</junit.version>
-        <kafka-clients.version>4.0.0</kafka-clients.version>
+        <kafka-clients.version>4.0.2</kafka-clients.version>
         <kafka-models.version>3.0.30</kafka-models.version>
         <log4j-version>2.24.2</log4j-version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
@@ -35,12 +35,17 @@
         <org.mapstruct.version>1.6.2</org.mapstruct.version>
         <private-api-sdk-java.version>4.0.490</private-api-sdk-java.version>
         <rest-service-common-library-version>2.0.2</rest-service-common-library-version>
-        <spring-boot.version>3.5.11</spring-boot.version>
-        <structured-logging.version>3.0.37</structured-logging.version>
+        <spring-boot.version>3.5.15</spring-boot.version>
+        <structured-logging.version>3.0.57</structured-logging.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <grpc-context.version>1.73.0</grpc-context.version>
         <gson.version>2.13.1</gson.version>
         <spring-boot-testcontainers-version>3.4.5</spring-boot-testcontainers-version>
+
+        <!-- Remove this if spring-boot > 3.5.15 updated this dependency to >= 2.25.4 -->
+        <log4j-api.version>2.25.4</log4j-api.version>
+        <!-- Remove this if structured-logging version > 3.0.57 updated this dependency to >= 1.42.0 -->
+        <open-telemetry.version>1.42.0</open-telemetry.version>
 
         <sonar-maven-plugin.version>5.5.0.6356</sonar-maven-plugin.version>
         <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
@@ -84,21 +89,26 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Temporarily overridden dependencies -->
-            <!--
-                Override dependency to fix CVE-2025-68161
-                Review to see if spring-boot-starter-logging > 3.5.10
-                supplies an updated version of this,
-                allowing removal of this dependency.
-            -->
+            <!-- Remove this if spring-boot > 3.5.15 updated this dependency to >= 2.25.4 -->
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>2.25.3</version>
+                <version>${log4j-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>${log4j-api.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <!-- Remove this if structured-logging version > 3.0.57 updated this dependency to >= 1.42.0 -->
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>${open-telemetry.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -124,7 +134,6 @@
             </exclusions>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.apache.avro/avro -->
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
@@ -174,11 +183,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/uk/gov/companieshouse/chs/notification/sender/api/TestUtil.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/sender/api/TestUtil.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.chs.notification.sender.api;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
 import uk.gov.companieshouse.api.chs.notification.sender.model.Address;
 import uk.gov.companieshouse.api.chs.notification.sender.model.EmailDetails;
 import uk.gov.companieshouse.api.chs.notification.sender.model.GovUkEmailDetailsRequest;
@@ -45,7 +47,7 @@ public class TestUtil {
                 .senderDetails(createDefaultSenderDetails())
                 .recipientDetails(createDefaultRecipientDetailsEmail())
                 .emailDetails(createDefaultEmailDetails())
-                .createdAt(OffsetDateTime.now());
+                .createdAt(OffsetDateTime.now(ZoneId.of("UTC")));
     }
 
     public static GovUkLetterDetailsRequest createValidLetterRequest() {
@@ -53,7 +55,7 @@ public class TestUtil {
                 .senderDetails(createDefaultSenderDetails())
                 .recipientDetails(createDefaultRecipientDetailsLetter())
                 .letterDetails(createDefaultLetterDetails())
-                .createdAt(OffsetDateTime.now());
+                .createdAt(OffsetDateTime.now(ZoneId.of("UTC")));
     }
 
     public static SenderDetails createDefaultSenderDetails() {


### PR DESCRIPTION
This pull request updates dependencies in the `pom.xml` to address security vulnerabilities and ensure compatibility, and makes a minor improvement to time zone handling in test utilities. The most significant changes include updating core dependencies, adding explicit dependency versions to mitigate CVEs, and ensuring consistent UTC timestamps in tests.

**Dependency Updates and Security Fixes:**

* Updated `spring-boot` to version `3.5.15`, `structured-logging` to `3.0.57`, and `kafka-clients` to `4.0.2` for improved stability and security. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L27-R27) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L38-R49)
* Added explicit versions for `log4j-api` (`2.25.4`), `log4j-to-slf4j` (`2.25.4`), and `opentelemetry-semconv` (`1.42.0`) to address CVEs and ensure compatibility; included comments to remove these overrides once upstream dependencies are updated. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L38-R49) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L87-R111)
* Updated dependency management to use property variables for easier maintenance and future upgrades.

**Dependency Cleanup:**

* Removed the redundant `spring-boot-testcontainers` test dependency, likely because it is no longer needed or provided transitively.

**Test Utilities Improvement:**

* Updated `TestUtil` to use `OffsetDateTime.now(ZoneId.of("UTC"))` instead of the system default, ensuring consistent UTC timestamps in tests. [[1]](diffhunk://#diff-5ea225d3d44420b7b074a448a9c963530353df3c69aee063b6437c7ceba46665R4-R5) [[2]](diffhunk://#diff-5ea225d3d44420b7b074a448a9c963530353df3c69aee063b6437c7ceba46665L48-R58)